### PR TITLE
Mmeyer/pass llm errors

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -72,6 +72,7 @@ async def json_500_handler(request: Request, exc: Exception):
 
 app.include_router(
     root.router,
+    include_in_schema=False,
     prefix=""
 )
 

--- a/app/main.py
+++ b/app/main.py
@@ -8,11 +8,10 @@ import logging
 from app.logs.logging_config import setup_structlog
 from app.logs.middleware import StructlogMiddleware
 from app.logs.logging_context import request_id_ctx
-from app.routers import api_v1
+from app.routers import api_v1, root
 
 from app.db.session import engine
 from app.services.billing import billing_worker, drain_billing_queue
-
 
 # this is only here until we actually use the users model
 # somewhere other than a relationship. SqlAlchemy has trouble
@@ -71,6 +70,10 @@ async def json_500_handler(request: Request, exc: Exception):
         }
     )
 
+app.include_router(
+    root.router,
+    prefix=""
+)
 
 app.include_router(
     api_v1.router,

--- a/app/providers/exceptions.py
+++ b/app/providers/exceptions.py
@@ -1,14 +1,14 @@
-class InputDataError(Exception):
+class InvalidInput(Exception):
     """Exception raised for errors caused by invalid input data format or content."""
     def __init__(self, message: str, field_name: str | None = None, original_exception: Exception | None= None):
         super().__init__(message)
         self.field_name = field_name
         self.original_exception = original_exception
 
-class InvalidBase64DataError(InputDataError):
+class InvalidBase64DataError(InvalidInput):
     """Error for failures during Base64 decoding."""
     pass
 
-class InvalidImageURLError(InputDataError):
+class InvalidImageURLError(InvalidInput):
     """Error for failures during data:url decoding."""
     pass

--- a/app/providers/open_ai/schemas.py
+++ b/app/providers/open_ai/schemas.py
@@ -1,4 +1,14 @@
-from pydantic import BaseModel, Field, confloat, ConfigDict, NonNegativeInt, field_serializer, Base64Bytes, PositiveInt, StringConstraints
+from pydantic import (
+    Base64Bytes,
+    BaseModel,
+    ConfigDict,
+    confloat,
+    Field,
+    field_serializer,
+    NonNegativeInt,
+    PositiveInt,
+    StringConstraints
+)
 from typing import Literal, Optional, Union, List, Annotated, Sequence
 from datetime import datetime
 

--- a/app/providers/open_ai/schemas.py
+++ b/app/providers/open_ai/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, confloat, ConfigDict, NonNegativeInt, field_serializer, Base64Bytes, PositiveInt
+from pydantic import BaseModel, Field, confloat, ConfigDict, NonNegativeInt, field_serializer, Base64Bytes, PositiveInt, StringConstraints
 from typing import Literal, Optional, Union, List, Annotated, Sequence
 from datetime import datetime
 
@@ -11,7 +11,10 @@ of which parts of the Chap Completion API we support.
 
 """
 
-
+non_empty_string = Annotated[
+        str,
+        StringConstraints(strip_whitespace=True, min_length=1)
+    ]
 class ImageUrl(BaseModel):
     """
     Defines the structure for an image URL input.
@@ -36,7 +39,7 @@ class TextContentPart(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     type: Literal["text"] = "text"
-    text: str
+    text: non_empty_string
 
 class FileContentPart(BaseModel):
     """Represents a file"""
@@ -59,7 +62,7 @@ class Message(BaseModel):
 class UserMessage(Message):
     model_config = ConfigDict(extra="ignore")
     role: Literal["user"] = "user"
-    content: Union[str, Sequence[ContentPart]] = Field(description="The content of the message. Can be a string, a list of content parts (for multimodal input)")
+    content: Union[non_empty_string, Sequence[ContentPart]] = Field(description="The content of the message. Can be a string, a list of content parts (for multimodal input)")
     name: Optional[str] = None
 
 class SystemMessage(Message):

--- a/app/providers/vertex_ai/vertexai.py
+++ b/app/providers/vertex_ai/vertexai.py
@@ -34,6 +34,16 @@ class VertexModelsSettings(BaseSettings):
         id="gemini-2.0-flash",
         capability="chat"
     )
+    gemini_2_0_flash_light:VertexModel = VertexModel(
+        name="Gemini 2.0 Flash Light",
+        id="gemini-2.0-flash-lite",
+        capability="chat"
+    )
+    gemini_2_5_pro:VertexModel = VertexModel(
+        name="Gemini 2.5 Pro",
+        id="gemini-2.5-pro-preview-05-06",
+        capability="chat"
+    )
     text_embedding_005:VertexModel = VertexModel(
         name="Text embedding 005",
         id="text-embedding-005",

--- a/app/routers/api_v1.py
+++ b/app/routers/api_v1.py
@@ -5,7 +5,7 @@ from app.auth.dependencies import RequiresScope, valid_api_key
 from app.auth.schemas import Scope
 from app.providers.base import LLMModel
 from app.providers.dependencies import Backend
-from app.providers.exceptions import InputDataError
+from app.providers.exceptions import InvalidInput
 from app.config.settings import get_settings
 from app.providers.open_ai.schemas import ChatCompletionRequest, ChatCompletionResponse, EmbeddingRequest, EmbeddingResponse
 from app.providers.open_ai.adapter_to_core import openai_chat_request_to_core, openai_embed_request_to_core
@@ -31,7 +31,7 @@ async def converse(
         core_req = openai_chat_request_to_core(req)
         resp = await backend.invoke_model(core_req)
         return core_chat_response_to_openai(resp)
-    except InputDataError as e:
+    except InvalidInput as e:
         error_detail = {"error": "Bad Request", "message": str(e)}
         if e.field_name:
             error_detail["field"] = e.field_name

--- a/app/routers/root.py
+++ b/app/routers/root.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, HTTPException
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError, NoResultFound
+import structlog
+
+from app.db.session import async_session
+
+
+log = structlog.get_logger()
+
+router = APIRouter()
+
+
+@router.get("/health")
+async def healthcheck():
+    async with async_session() as session:
+        try:
+            result = await session.execute(text('SELECT 1'))
+            result.scalar_one
+        except NoResultFound as e:
+            log.error(f"Database health check failed: SELECT 1 returned no result. {e}")
+            raise HTTPException(
+                status_code=503,
+                detail=f"Database health check failed: Core query returned no result. {str(e)}"
+            )
+        except SQLAlchemyError as e: 
+            log.error(f"Database health check failed: {e}")
+            raise HTTPException(
+                status_code=503,
+                detail=f"Database connection error: {str(e)}"
+            )
+        except Exception as e: #
+            log.error(f"An unexpected error occurred during health check: {e}")
+            raise HTTPException(
+                status_code=500,
+                detail=f"An unexpected error occurred: {str(e)}"
+            )
+        return {"status": True}


### PR DESCRIPTION
Adds:

- health check end point. This will be needed for FCS to check if pods are healthy. Right now it just checks that it can connect to the database
- Catch validation errors from the LLM endpoints and return them to users. Previously these resulted in 500 errors.
- Add some better validation on the front end interface (empty prompts are errors on all models we are using — might as well let FastAPI catch that rather than sending it to the LLM)