### PR TITLE
Mmeyer/updat user

### DIFF
--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -36,10 +36,8 @@ async def valid_api_key(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="API key is expired"
             ) 
-    print("orm key:", api_key.manager)
-    key = APIKeyOut.model_validate(api_key)
-    print("Key:", key)
-    return key
+
+    return APIKeyOut.model_validate(api_key)
         
 
 class RequiresScope:

--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -36,8 +36,10 @@ async def valid_api_key(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="API key is expired"
             ) 
-
-    return api_key
+    print("orm key:", api_key.manager)
+    key = APIKeyOut.model_validate(api_key)
+    print("Key:", key)
+    return key
         
 
 class RequiresScope:

--- a/app/auth/repositories.py
+++ b/app/auth/repositories.py
@@ -1,4 +1,5 @@
 from sqlalchemy import select
+from sqlalchemy.orm import joinedload
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth.models import APIKey
 from app.auth.schemas import APIKeyCreate
@@ -21,5 +22,17 @@ class APIKeyRepository:
         result = await self.session.execute(
             select(APIKey).where(APIKey.hashed_key == hashed_key)
         )
+        return result.scalars().one_or_none()
+    
+    async def get_by_id_with_manager(self, api_key_id: int) -> APIKey | None:
+        """Fetches an APIKey and eagerly loads its manager (User)."""
+        stmt = (
+            select(APIKey)
+            .where(APIKey.id == api_key_id)
+            .options(
+                joinedload(APIKey.manager)
+            )
+        )
+        result = await self.session.execute(stmt)
         return result.scalars().one_or_none()
  

--- a/app/auth/repositories.py
+++ b/app/auth/repositories.py
@@ -1,32 +1,25 @@
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth.models import APIKey
-from app.auth.schemas import APIKeyCreate, APIKeyOut
+from app.auth.schemas import APIKeyCreate
 import hashlib
 
 class APIKeyRepository:
     def __init__(self, session:AsyncSession):
         self.session = session
 
-    async def create(self, token: APIKeyCreate) -> APIKeyOut:
+    async def create(self, token: APIKeyCreate) -> APIKey:
         new_api_key = APIKey(**token.model_dump())
 
-        async with self.session.begin():
-            self.session.add(new_api_key)
-            await self.session.commit()
+        self.session.add(new_api_key)
+        return new_api_key
             
-        await self.session.refresh(new_api_key)
-        return APIKeyOut.model_validate(new_api_key)
-
-    async def get_by_api_key_value(self, provided_key: str) -> APIKeyOut | None:
+    async def get_by_api_key_value(self, provided_key: str) -> APIKey | None:
         '''Api keys are not stored. Given an API key, first get it's hash and use that for the query'''
         hashed_key = hashlib.sha256(provided_key.encode('utf-8')).hexdigest()
 
-        async with self.session.begin():
-            result = await self.session.execute(
-                select(APIKey).where(APIKey.hashed_key == hashed_key)
-            )
-            result = result.scalars().first()
-            if result is not None:
-                return APIKeyOut.model_validate(result)
-
+        result = await self.session.execute(
+            select(APIKey).where(APIKey.hashed_key == hashed_key)
+        )
+        return result.scalars().one_or_none()
+ 

--- a/app/common/exceptions.py
+++ b/app/common/exceptions.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+class RepositoryError(Exception):
+    """Base class for repository-related errors."""
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message
+
+class ResourceNotFoundError(RepositoryError):
+    """Raised when a resource is not found in a repository."""
+    def __init__(self, resource_name: str, identifier: Any):
+        self.resource_name = resource_name
+        self.identifier = identifier
+        super().__init__(f"{resource_name} with identifier '{identifier}' not found.")
+
+class DuplicateResourceError(RepositoryError):
+    """Raised when attempting to create a resource that already exists (e.g., unique constraint)."""
+    def __init__(self, resource_name: str, identifier: Any):
+        self.resource_name = resource_name
+        self.identifier = identifier
+        super().__init__(f"{resource_name} with identifier '{identifier}' already exists.")

--- a/app/main.py
+++ b/app/main.py
@@ -111,5 +111,6 @@ app.include_router(
 
 app.include_router(
     auth.router,
-    prefix="/users"
+    prefix="/users",
+    include_in_schema=False
 )

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, Depends
+from pydantic import EmailStr
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.users.schemas import UserCreate, UserOut, UserUpdate
+from app.users.repositories import UserRepository
+from app.auth.dependencies import RequiresScope
+from app.auth.schemas import Scope
+from app.db.session import get_db_session
+
+
+
+router = APIRouter()
+
+@router.post("/create")
+async def create_user(
+    user: UserCreate, 
+    api_key=Depends(RequiresScope([Scope.ADMIN])),
+    session: AsyncSession = Depends(get_db_session)
+) -> UserOut:
+    user_repo = UserRepository(session)
+    async with session.begin():
+        new_user = await user_repo.create(user)
+    
+    await session.refresh(new_user) 
+    return UserOut.model_validate(new_user)
+        
+@router.post("/update/{email}")
+async def converse(
+    update: UserUpdate,
+    email:EmailStr,
+    api_key=Depends(RequiresScope([Scope.ADMIN])),
+    session: AsyncSession = Depends(get_db_session),
+) -> UserOut:
+    user_repo = UserRepository(session)
+    async with session.begin():
+        updated_user_orm = await user_repo.update(email=email, user=update)
+    await session.refresh(updated_user_orm) 
+    return UserOut.model_validate(updated_user_orm)
+        

--- a/app/users/repositories.py
+++ b/app/users/repositories.py
@@ -16,6 +16,7 @@ class UserRepository:
             raise DuplicateResourceError(resource_name="User", identifier=new_user.email)
         
         self.session.add(new_user)
+        await self.session.flush([new_user])
         return new_user        
 
     async def get(self, user_id: str) -> User | None:

--- a/app/users/repositories.py
+++ b/app/users/repositories.py
@@ -2,34 +2,42 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.users.models import User
-from app.users.schemas import UserCreate, UserOut
+from app.users.schemas import UserCreate, UserUpdate
+from app.common.exceptions import ResourceNotFoundError, DuplicateResourceError
 
 class UserRepository:
     def __init__(self, session: AsyncSession) -> None:
         self.session = session
         
-    async def create(self,user:UserCreate) -> UserOut:
+    async def create(self,user:UserCreate) -> User:
         new_user = User(**user.model_dump())
-        async with self.session.begin():
-            self.session.add(new_user)           
-        await self.session.refresh(new_user)
-        return UserOut.model_validate(new_user)
+        existing_user = await self.get_by_email(new_user.email)
+        if existing_user is not None:
+            raise DuplicateResourceError(resource_name="User", identifier=new_user.email)
+        
+        self.session.add(new_user)
+        return new_user        
 
-    async def get(self, user_id: str) -> UserOut | None:
-        async with self.session.begin():
-            result = await self.session.execute(
-                select(User).where(User.id==user_id)
-            )
-            result = result.scalars().first()
-            if result is not None:
-                return UserOut.model_validate(result)
+    async def get(self, user_id: str) -> User | None:
+        result = await self.session.execute(
+            select(User).where(User.id==user_id)
+        )
+        return result.scalars().one_or_none()
     
-    async def get_by_email(self, email: str) -> UserOut | None:
-        async with self.session.begin():
-            result = await self.session.execute(
-                select(User).where(User.email==email)
-            )
-            result = result.scalars().first()
+    async def get_by_email(self, email: str) -> User | None:
+        result = await self.session.execute(
+            select(User).where(User.email==email)
+        )
+        result = result.scalars().first()
+        return result
 
-            if result is not None:
-                return UserOut.model_validate(result)
+    async def update(self, email:str, user:UserUpdate) -> User:
+        to_update = await self.get_by_email(email)
+        if to_update is None:
+            raise ResourceNotFoundError(resource_name='User', identifier=email)
+
+        values = user.model_dump(exclude_unset=True)
+        for k, v in values.items():
+            setattr(to_update, k, v)
+
+        return to_update

--- a/app/users/schemas.py
+++ b/app/users/schemas.py
@@ -14,8 +14,11 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     pass
 
-class UserUpdate(UserBase):
-    pass
+class UserUpdate(BaseModel):
+    name: str | None = None
+    email: EmailStr | None = None
+    role: Role | None = None
+    is_active: bool | None = None
 
 class UserOut(UserBase):
     id: UUID4 

--- a/create_admin_user.py
+++ b/create_admin_user.py
@@ -16,7 +16,7 @@ except ImportError as e:
           "use `uv run` (see Readme)")
     sys.exit(1)
 
-SCOPES = [Scope.MODELS_INFERENCE, Scope.MODELS_EMBEDDING]
+SCOPES = [Scope.MODELS_INFERENCE, Scope.MODELS_EMBEDDING, Scope.ADMIN]
 KEY_PREFIX = "test_adm"
 
 async def create_admin_user(email: str, name: str, key_length: int):

--- a/create_admin_user.py
+++ b/create_admin_user.py
@@ -25,50 +25,52 @@ async def create_admin_user(email: str, name: str, key_length: int):
     """
 
     secret_key, key_hash = generate_api_key(KEY_PREFIX, key_length)
+    async with async_session() as session:
+        try:
+            async with session.begin():
+                user_repo = UserRepository(session)
+                existing_user = await user_repo.get_by_email(email)
+                if existing_user:
+                    raise ValueError(f"User with email '{email}' already exists.")
 
-    try:
-        # Create the user schema
-        user_schema = UserCreate(
-            email=email,
-            name=name,
-            role=Role.ADMIN, 
-        )
+                user_schema = UserCreate(
+                    email=email,
+                    name=name,
+                    role=Role.ADMIN, 
+                )
+                created_user_orm = await user_repo.create(user_schema)
+                if not created_user_orm.id:
+                    await session.flush([created_user_orm])
 
-        async with async_session() as session:
-            user_repo = UserRepository(session)
-            existing_user = await user_repo.get_by_email(email)
-            if existing_user:
-                print(f"Error: User with email '{email}' already exists.")
-                return 
+                api_key_schema = APIKeyCreate(
+                    hashed_key=key_hash,
+                    key_prefix=KEY_PREFIX,
+                    manager_id=created_user_orm.id,
+                    scopes=SCOPES
+                )
+                await APIKeyRepository(session).create(api_key_schema)
+            await session.refresh(created_user_orm)
 
-            new_user = await user_repo.create(user_schema)
+            print("\n" + "=" * 50)
+            print("  ADMIN USER AND API KEY CREATED SUCCESSFULLY!")
+            print("  Email:", created_user_orm.email)
+            print("  Name:", created_user_orm.name)
+            print("  User ID:", created_user_orm.id)
+            print("\n  IMPORTANT: Save the following API key. It cannot be recovered.")
+            print(f"  API Key: {secret_key}")
+            print("=" * 50 + "\n")
 
-        async with async_session() as session:
-            api_key_schema = APIKeyCreate(
-                hashed_key=key_hash,
-                key_prefix=KEY_PREFIX,
-                manager_id=new_user.id,
-                scopes=SCOPES
-            )
-            await APIKeyRepository(session).create(api_key_schema)
-
-
-        print("\n" + "=" * 50)
-        print("  ADMIN USER AND API KEY CREATED SUCCESSFULLY!")
-        print("  Email:", new_user.email)
-        print("  Name:", new_user.name)
-        print("  User ID:", new_user.id)
-        print("\n  IMPORTANT: Save the following API key. It cannot be recovered.")
-        print(f"  API Key: {secret_key}")
-        print("=" * 50 + "\n")
-
-    except Exception as e:
-        print(f"\nError during admin user creation: {e}")
-        sys.exit(1)
+        except ValueError as ve: # 
+            print(f"\nError: {ve}")
+            sys.exit(1)
+        except Exception as e:
+            print(f"\nError during admin user creation: {e}")
+            import traceback
+            traceback.print_exc()
+            sys.exit(1)
 
 
 def main():
-  
     parser = argparse.ArgumentParser(
         description="Create an admin user and their API key."
     )

--- a/tests/unit/auth/test_authentication.py
+++ b/tests/unit/auth/test_authentication.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials
 from app.auth.dependencies import valid_api_key
 from app.auth.schemas import APIKeyOut
+from app.auth.models import APIKey
 
 
 
@@ -25,10 +26,11 @@ def api_key() -> HTTPAuthorizationCredentials:
 @pytest.fixture(scope="module") 
 def good_api_key():
     now = datetime.now()
-    return APIKeyOut(
+    return APIKey(
         id=1,
         hashed_key="xyzabc",
         key_prefix="testing",
+        scopes=[],
         manager_id=uuid.uuid4(),
         is_active=True,
         created_at=now,
@@ -113,7 +115,7 @@ async def test_get_api_key_valid_key(mocker, good_api_key, api_key):
 
     returned_key = await valid_api_key(credentials=api_key, session=mock_session)
 
-    assert returned_key == good_api_key
+    assert returned_key == APIKeyOut.model_validate(good_api_key)
     assert returned_key.is_active is True
 
 


### PR DESCRIPTION
Changes:
- Adjusts the create key utility script to be atomic so it will roll back the created user if creating the token fails. Also puts ADMIN scope on the key
- Adds some routes for creating and editing users. We don't want to do too much work here since this will be handled by an external KeyCloak services, but this will be helpful until then
- Adjusts database repositories to return orm objects instead of pydantic models. This is in better alignment with the pattern and the idea of a unit-of-work. It also gives routes more flexibility to manage sessions.
- Slightly more granular error handling 