### PR TITLE
remove bedrock assumed role -- it's not being used right now

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -2,8 +2,6 @@ BEDROCK_MODELS__LLAMA3211B__ARN="arn:aws:bedrock:..."
 BEDROCK_MODELS__CLAUDE_3_5_SONNET__ARN="arn:aws:bedrock:..."
 BEDROCK_MODELS__COHERE_ENGLISH_V3__ARN="cohere.embed-english-v3"
 
-
-BEDROCK_ASSUME_ROLE="arn:aws:iam:..."
 AWS_DEFAULT_REGION="us-east-1"
 
 VERTEX_PROJECT_ID="some_project…"

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -33,7 +33,6 @@ class Settings(BaseSettings):
     database_echo: bool = False
     google_application_credentials: str = Field(default=...)
     
-    bedrock_assume_role:str = Field(default=...)
     aws_default_region:str = Field(default=...)
 
     backend_map:dict[str,tuple[Backend, LLMModel]]

--- a/app/providers/bedrock/bedrock.py
+++ b/app/providers/bedrock/bedrock.py
@@ -84,7 +84,6 @@ class BedrockModelsSettings(BaseSettings):
 class BedRockBackend(Backend):
     class Settings(BaseSettings):
         model_config = SettingsConfigDict(env_file='.env',extra='ignore', env_file_encoding='utf-8', env_nested_delimiter="__" )
-        bedrock_assume_role: str = Field(default=...)
         aws_default_region: str = Field(default=...)
         bedrock_models: BedrockModelsSettings = BedrockModelsSettings()
         


### PR DESCRIPTION
This isn't being used right now and if we need it, we don't know the value. Removing until we know how FCS pods are handling IAM.